### PR TITLE
Replacing deprecated MPI functions by their new counterpart

### DIFF
--- a/definitions/mpiDefinitions.xml
+++ b/definitions/mpiDefinitions.xml
@@ -452,5 +452,5 @@
     <define name="MPI_COMBINER_STRUCT_INTEGER" version="2.0" deprecated="3.0" />
     <typedef name="MPI_Copy_function" version="1.0"/>
     <typedef name="MPI_Delete_function" version="1.0"/>
-    <typedef name="MPI_Handler_function" version="1.0"/>
+    <typedef name="MPI_Comm_errhandler_function" version="1.0"/>
 </definitions>

--- a/definitions/mpiFunctions.xml
+++ b/definitions/mpiFunctions.xml
@@ -2942,7 +2942,7 @@
       </function>
 
       <function name="Errhandler_create" version="1.0" deprecated="3.0">
-        <arg name="function" type="MPI_Handler_function*" />
+        <arg name="function" type="MPI_Comm_errhandler_function" />
         <arg name="errhandler" type="MPI_Errhandler*" />
       </function>
 

--- a/generated/medi/ampiDefinitions.h
+++ b/generated/medi/ampiDefinitions.h
@@ -875,7 +875,7 @@ namespace medi {
   typedef MPI_Delete_function AMPI_Delete_function;
 #endif
 #if MEDI_MPI_VERSION_1_0 <= MEDI_MPI_TARGET
-  typedef MPI_Handler_function AMPI_Handler_function;
+  typedef MPI_Comm_errhandler_function AMPI_Comm_errhandler_function;
 #endif
 
   void initializeOperators();

--- a/include/medi/ampi/constructedDatatypes.hpp
+++ b/include/medi/ampi/constructedDatatypes.hpp
@@ -497,8 +497,8 @@ namespace medi {
     MPI_Aint* array_of_displacements = new MPI_Aint [typeCount];
     MpiTypeInterface** array_of_types = new MpiTypeInterface*[typeCount];
 
-    MPI_Aint extent;
-    MPI_Type_extent(oldtype->getMpiType(), &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(oldtype->getMpiType(), &lb, &extent);
     for(int i = 0; i < count; ++i) {
       array_of_blocklengths[i] = blocklength;
       array_of_displacements[i] = stride * extent * i;
@@ -544,8 +544,8 @@ namespace medi {
     MPI_Aint* array_of_displacements_byte = new MPI_Aint [typeCount];
     MpiTypeInterface** array_of_types = new MpiTypeInterface*[typeCount];
 
-    MPI_Aint extent;
-    MPI_Type_extent(oldtype->getMpiType(), &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(oldtype->getMpiType(), &lb, &extent);
     for(int i = 0; i < count; ++i) {
       array_of_displacements_byte[i] = array_of_displacements[i] * extent * i;
       array_of_types[i] = oldtype;
@@ -584,8 +584,8 @@ namespace medi {
     MPI_Aint* array_of_displacements_byte = new MPI_Aint [typeCount];
     MpiTypeInterface** array_of_types = new MpiTypeInterface*[typeCount];
 
-    MPI_Aint extent;
-    MPI_Type_extent(oldtype->getMpiType(), &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(oldtype->getMpiType(), &lb, &extent);
     for(int i = 0; i < count; ++i) {
       array_of_blocklengths[i] = blocklength;
       array_of_displacements_byte[i] = array_of_displacements[i] * extent * i;
@@ -672,8 +672,8 @@ namespace medi {
     }
 
     // compute the total extend of all the blocks
-    MPI_Aint extent;
-    MPI_Type_extent(oldtype->getMpiType(), &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(oldtype->getMpiType(), &lb, &extent);
     MPI_Aint* extends = new MPI_Aint [ndims];
     MPI_Aint curExtent = extent;
     for(int i = ndims - 1; i >= 0; --i) {


### PR DESCRIPTION
The 'MPI_Handler_function' and 'MPI_Type_extent' were deprecated in MPI
2.0 and removed in MPI 3.0. Replace them by their new counterparts
'MPI_Comm_errhandler_function' and 'MPI_Type_get_extent'.