### PR TITLE
explicitly specify CXX language in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ project(
   ${MEDIPACK_NAME}
   VERSION ${MEDIPACK_VERSION}
   DESCRIPTION "MeDiPack - Message Differentiation Package"
-  HOMEPAGE_URL "http://scicomp.rptu.de/software/medi")
+  HOMEPAGE_URL "http://scicomp.rptu.de/software/medi"
+  LANGUAGES CXX)
 
 set(DEFAULT_BUILD_TYPE "Release")
 


### PR DESCRIPTION
No C compiler is needed. If the LANGUAGES part is omitted it defaults to C CXX, which interferes with spack builds among other things.

See SciCompKL/CoDiPack#47 for the equivalent change.